### PR TITLE
fixed bug in method _fixACLRuleRedundancy()

### DIFF
--- a/lib/cisco2checkpoint.py
+++ b/lib/cisco2checkpoint.py
@@ -2045,13 +2045,16 @@ class Cisco2Checkpoint(CiscoObject):
         print_msg('Merging redundant ACL rules')
         aclRules = [obj for obj in self.obj_list \
                      if isinstance(obj, CiscoACLRule)]
+        aclRulesRemovedIndices = []
         
         for i in range(0,len(aclRules)-2):
-            for j in range(i+1,len(aclRules)-2):
-                if self._areMergable(aclRules[i], aclRules[j]):
-                    self._mergeRules(aclRules[i], aclRules[j])
-                    if aclRules[j] in self.obj_list:
-                        self.removeObj(aclRules[j])
+            if i not in aclRulesRemovedIndices:
+                for j in range(i+1,len(aclRules)-2):
+                    if self._areMergable(aclRules[i], aclRules[j]):
+                        self._mergeRules(aclRules[i], aclRules[j])
+                        if aclRules[j] in self.obj_list:
+                            self.removeObj(aclRules[j])
+                            aclRulesRemovedIndices.append(j)
         self.aclRuCt = len(self.findNewObjByType(['CiscoACLRule']))
         
     def _areMergable(self, obj1, obj2):


### PR DESCRIPTION
In some cases, ACLs were removed/lost by method _fixACLRuleRedundancy() because of a bug.
If we had ACL_a, ACL_b, and ACL_c where ACL_a can be merged with ACL_b, and ACL_b can be merged with ACL_c, then this happend:
ACL_a was merged with ACL_b and ACL_b was removed from self.obj_list but retained in local aclRules 
ACL_b was merged with ACL_c and ACL_c was removed from self.obj_list